### PR TITLE
role-description => aria-roledescription

### DIFF
--- a/examples/barchart-001-html.html
+++ b/examples/barchart-001-html.html
@@ -77,7 +77,7 @@
   <section>
     <h2>role="region"</h2>
     <div id="bar-chart-001" role="region" aria-label="bar chart">
-      <!-- role-description="bar chart"       -->
+      <!-- aria-roledescription="bar chart"       -->
       <div id="bar-one">
         <span class="year">2017</span>
         <div class="bar" data-percentage="69.6%"></div>
@@ -100,7 +100,7 @@
   <section>
     <h2>role="graphics-document"</h2>
     <div id="bar-chart-001" role="graphics-document" aria-label="bar chart">
-      <!-- role-description="bar chart"       -->
+      <!-- aria-roledescription="bar chart"       -->
       <div id="bar-one">
         <span class="year">2017</span>
         <div class="bar" data-percentage="69.6%"></div>
@@ -124,7 +124,7 @@
   <section>
     <h2>role="graphics-object"</h2>
     <div id="bar-chart-001" role="graphics-object">
-      <!-- role-description="bar chart"       -->
+      <!-- aria-roledescription="bar chart"       -->
       <div id="bar-one">
         <span class="year">2017</span>
         <div class="bar" data-percentage="69.6%"></div>

--- a/examples/barchart-001-svg.svg
+++ b/examples/barchart-001-svg.svg
@@ -1,56 +1,56 @@
 <svg id="bar-chart-001" xmlns="http://www.w3.org/2000/svg" 
   width="100%" height="100%" viewBox="0 0 500 500"
-  role="graphics-document" role-description="bar chart">
+  role="graphics-document" aria-roledescription="bar chart">
   <title>Accessible SVG Chart</title>  
 
   <rect class="bg" width="100%" height="100%" fill="navajowhite"/>
 
   <style>
 
-    #bar-one [role-description=bar] {
+    #bar-one [aria-roledescription=bar] {
       fill: #64b2d1;
     }
 
-    #bar-two [role-description=bar] {
+    #bar-two [aria-roledescription=bar] {
       fill: #5292ac;
     }
 
-    #bar-three [role-description=bar] {
+    #bar-three [aria-roledescription=bar] {
       fill: #407286;
     }
 
-    #bar-chart-001 #bar-four [role-description=bar] {
+    #bar-chart-001 #bar-four [aria-roledescription=bar] {
       fill: #2e515f;
     }
 
   </style>
 
   <g id="dataset">
-    <g id="bar-one" role="graphics-object" role-description="datapoint" aria-labelledby="year-2019" tabindex="0"
+    <g id="bar-one" role="graphics-object" aria-roledescription="datapoint" aria-labelledby="year-2019" tabindex="0"
       transform="translate(30,10)">
       <text id="year-2017" class="year">2017</text>
-      <rect role="graphics-symbol" role-description="bar" aria-label="69.6%" tabindex="0"
+      <rect role="graphics-symbol" aria-roledescription="bar" aria-label="69.6%" tabindex="0"
         width="69.6%" height="50"></rect>
     </g>
 
-    <g id="bar-two" role="graphics-object" role-description="datapoint" aria-labelledby="year-2019" tabindex="0"
+    <g id="bar-two" role="graphics-object" aria-roledescription="datapoint" aria-labelledby="year-2019" tabindex="0"
       transform="translate(30,70)">
       <text id="year-2018" class="year">2018</text>
-      <rect class="bar" role="graphics-symbol" role-description="bar" aria-label="71%" tabindex="0"
+      <rect class="bar" role="graphics-symbol" aria-roledescription="bar" aria-label="71%" tabindex="0"
         width="71%" height="50"></rect>
     </g>
 
-    <g id="bar-three" role="graphics-object" role-description="datapoint" aria-labelledby="year-2019" tabindex="0"
+    <g id="bar-three" role="graphics-object" aria-roledescription="datapoint" aria-labelledby="year-2019" tabindex="0"
       transform="translate(30,130)">
       <text id="year-2019" class="year">2019</text>
-      <rect class="bar" role="graphics-symbol" role-description="bar" aria-label="74.7%" tabindex="0"
+      <rect class="bar" role="graphics-symbol" aria-roledescription="bar" aria-label="74.7%" tabindex="0"
         width="74.7%" height="50"></rect>
     </g>
 
-    <g id="bar-four" role="graphics-object" role-description="datapoint" aria-labelledby="year-2019" tabindex="0"
+    <g id="bar-four" role="graphics-object" aria-roledescription="datapoint" aria-labelledby="year-2019" tabindex="0"
       transform="translate(30,200)">
       <text id="year-2020" class="year">2020</text>
-      <rect class="bar" role="graphics-symbol" role-description="bar" aria-label="76.8%" tabindex="0"
+      <rect class="bar" role="graphics-symbol" aria-roledescription="bar" aria-label="76.8%" tabindex="0"
         width="76.8%" height="50"></rect>
     </g>
 


### PR DESCRIPTION
Hello @shepazu, I stumbled upon this work and noticed `role-description` is used. Is it meant to be [`aria-roledescription`](https://www.w3.org/TR/wai-aria-1.1/#aria-roledescription)?

I had to take a look at the SVG AAM for `role-description` just in case that's something new, but didn't find it. 😋